### PR TITLE
Add synchronous loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,6 @@
     "**/*.mts",
     "**/*.cts",
     "**/*.map"
-  ]
+  ],
+  "sideEffects": false
 }

--- a/src/slot/getSlotContent.ts
+++ b/src/slot/getSlotContent.ts
@@ -1,0 +1,5 @@
+import type {JsonObject} from '@croct/json';
+
+export function getSlotContent(slotId: string, language?: string): JsonObject|null {
+    return null;
+}

--- a/src/slot/index.ts
+++ b/src/slot/index.ts
@@ -1,5 +1,2 @@
-import {JsonObject} from '@croct/json';
-
-export function getSlotContent(slotId: string, language?: string): Promise<JsonObject|null> {
-    return Promise.resolve(null);
-}
+export * from './getSlotContent';
+export * from './loadSlotContent';

--- a/src/slot/loadSlotContent.ts
+++ b/src/slot/loadSlotContent.ts
@@ -1,0 +1,5 @@
+import type {JsonObject} from '@croct/json';
+
+export function loadSlotContent(slotId: string, language?: string): Promise<JsonObject|null> {
+    return Promise.resolve(null);
+}

--- a/test/slot/getSlotContent.test.ts
+++ b/test/slot/getSlotContent.test.ts
@@ -1,0 +1,7 @@
+import {getSlotContent} from '../../src';
+
+describe('getSlotContent', () => {
+    it('should return null', () => {
+        expect(getSlotContent('bar', 'en')).toBeNull();
+    });
+});

--- a/test/slot/index.test.ts
+++ b/test/slot/index.test.ts
@@ -1,7 +1,0 @@
-import {getSlotContent} from '../../src';
-
-describe('getSlotContent', () => {
-    it('should return null', async () => {
-        await expect(getSlotContent('bar', 'en')).resolves.toBeNull();
-    });
-});

--- a/test/slot/loadSlotContent.test.ts
+++ b/test/slot/loadSlotContent.test.ts
@@ -1,0 +1,7 @@
+import {loadSlotContent} from '../../src';
+
+describe('loadSlotContent', () => {
+    it('should return null', async () => {
+        await expect(loadSlotContent('bar', 'en')).resolves.toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
This PR adds support for both synchronous and asynchronous content loading.

While asynchronous loading is generally preferred – since the bundle can split into chunks that load only on demand – synchronous loading is necessary to provide initial content for React hooks like useContent. Because the initial content is rendered exclusively on the server side, the fact that getSlotContent includes all content is not a concern.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings